### PR TITLE
Migrate from GitLab CI to GitHub Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,12 @@
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./gradlew test
+      - uses: actions/upload-artifact@v1
+        with:
+          name: server-test-results
+          path: build/reports/tests/test/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,0 @@
-image: zenika/kotlin:1.3.31-jdk8
-
-test:
-  script: ./gradlew test


### PR DESCRIPTION
@neelkamath 

This PR implements #3 : 
- Removes Gitlab CI specific files, adds Github-specific CI files.
- Implements artifact upload.